### PR TITLE
PinePhone Pro Support

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -149,6 +149,7 @@ chmod +x genfstab
 [ $FILESYSTEM = "ext4" ] && MKFS="mkfs.ext4"
 [ $FILESYSTEM = "f2fs" ] && MKFS="mkfs.f2fs"
 
+sudo parted -a optimal ${DISK_IMAGE} mklabel msdos --script
 if [ $DEVICE == "pinephone-pro" ]; then
   sudo parted -a optimal ${DISK_IMAGE} mkpart primary fat32 65536s 589823s --script
   sudo parted -a optimal ${DISK_IMAGE} mkpart primary ext4 589824s 100% --script
@@ -156,6 +157,7 @@ else
   sudo parted -a optimal ${DISK_IMAGE} mkpart primary fat32 '0%' 256MB --script
   sudo parted -a optimal ${DISK_IMAGE} mkpart primary ext4 256MB 100% --script
 fi
+sudo parted ${DISK_IMAGE} set 1 boot on --script
 
 # The first partition is the boot partition and the second one the root
 PARTITIONS=$(lsblk $DISK_IMAGE -l | grep ' part ' | awk '{print $1}')

--- a/installer.sh
+++ b/installer.sh
@@ -26,7 +26,7 @@ case $key in
         echo ""
         printf '%s\n' \
                "This script will download the latest encrypted image for the" \
-               "PinePhone and PineTab. It downloads and create a image for the user" \
+               "PinePhone, PinePhone Pro, and PineTab. It downloads and create a image for the user" \
                "to flash on their device or SD card." \
                "" \
                "usage: $0 " \

--- a/installer.sh
+++ b/installer.sh
@@ -105,7 +105,7 @@ SQFSROOT="archlinux-$DEVICE-$USR_ENV-$SQFSDATE.sqfs"
 echo -e "\e[1mWhich filesystem would you like to use?\e[0m"
 select OPTION in "ext4" "f2fs"; do
     case $OPTION in
-        "ext4" ) FILESYSTEM="ext4"; break;;
+        "ext4" ) FILESYSTEM="ext4"; gbreak;;
         "f2fs" ) FILESYSTEM="f2fs"; break;;
     esac
 done
@@ -149,10 +149,13 @@ chmod +x genfstab
 [ $FILESYSTEM = "ext4" ] && MKFS="mkfs.ext4"
 [ $FILESYSTEM = "f2fs" ] && MKFS="mkfs.f2fs"
 
-sudo parted -a optimal ${DISK_IMAGE} mklabel msdos --script
-sudo parted -a optimal ${DISK_IMAGE} mkpart primary fat32 '0%' 256MB --script
-sudo parted -a optimal ${DISK_IMAGE} mkpart primary ext4 256MB 100% --script
-sudo parted ${DISK_IMAGE} set 1 boot on --script
+if [ $DEVICE == "pinephone-pro" ]; then
+  sudo parted -a optimal ${DISK_IMAGE} mkpart primary fat32 65536s 589823s --script
+  sudo parted -a optimal ${DISK_IMAGE} mkpart primary ext4 589824s 100% --script
+else 
+  sudo parted -a optimal ${DISK_IMAGE} mkpart primary fat32 '0%' 256MB --script
+  sudo parted -a optimal ${DISK_IMAGE} mkpart primary ext4 256MB 100% --script
+fi
 
 # The first partition is the boot partition and the second one the root
 PARTITIONS=$(lsblk $DISK_IMAGE -l | grep ' part ' | awk '{print $1}')

--- a/installer.sh
+++ b/installer.sh
@@ -188,7 +188,12 @@ sudo unsquashfs -f -d $TMPMOUNT $SQFSROOT
 ./genfstab -U $TMPMOUNT | grep UUID | grep -v "swap" | sudo tee -a $TMPMOUNT/etc/fstab
 sudo sed -i "s:UUID=[0-9a-f-]*\s*/\s:/dev/mapper/cryptroot / :g" $TMPMOUNT/etc/fstab
 
-sudo dd if=${TMPMOUNT}/boot/u-boot-sunxi-with-spl-${DEVICE}-552.bin of=${DISK_IMAGE} bs=8k seek=1
+if [ $DEVICE == "pinephone-pro" ]; then
+  sudo dd if=${TMPMOUNT}/boot/idbloader.img of=${DISK_IMAGE} seek=64 conv=notrunc,fsync
+  sudo dd if=${TMPMOUNT}/boot/u-boot.itb of=${DISK_IMAGE} seek=16384 conv=notrunc,fsync
+else
+    sudo dd if=${TMPMOUNT}/boot/u-boot-sunxi-with-spl-${DEVICE}-552.bin of=${DISK_IMAGE} bs=8k seek=1
+fi
 
 sudo umount -R $TMPMOUNT
 sudo cryptsetup close $ENCRYNAME

--- a/installer.sh
+++ b/installer.sh
@@ -78,9 +78,10 @@ check_dependency "curl"
 
 # Image selection
 echo -e "\e[1mWhich image do you want to create?\e[0m"
-select OPTION in "PinePhone" "PineTab"; do
+select OPTION in "PinePhone" "PinePhone Pro" "PineTab"; do
     case $OPTION in
         "PinePhone" ) DEVICE="pinephone"; break;;
+        "PinePhone Pro" ) DEVICE="pinephone-pro"; break;;
         "PineTab" ) DEVICE="pinetab"; break;;
     esac
 done

--- a/installer.sh
+++ b/installer.sh
@@ -190,12 +190,8 @@ sudo unsquashfs -f -d $TMPMOUNT $SQFSROOT
 ./genfstab -U $TMPMOUNT | grep UUID | grep -v "swap" | sudo tee -a $TMPMOUNT/etc/fstab
 sudo sed -i "s:UUID=[0-9a-f-]*\s*/\s:/dev/mapper/cryptroot / :g" $TMPMOUNT/etc/fstab
 
-if [ $DEVICE == "pinephone-pro" ]; then
-  sudo dd if=${TMPMOUNT}/boot/idbloader.img of=${DISK_IMAGE} seek=64 conv=notrunc,fsync
-  sudo dd if=${TMPMOUNT}/boot/u-boot.itb of=${DISK_IMAGE} seek=16384 conv=notrunc,fsync
-else
-    sudo dd if=${TMPMOUNT}/boot/u-boot-sunxi-with-spl-${DEVICE}-552.bin of=${DISK_IMAGE} bs=8k seek=1
-fi
+[ "$DEVICE" != "pinephone-pro" ] && sudo dd if=${TMPMOUNT}/boot/u-boot-sunxi-with-spl-${DEVICE}-552.bin of=${DISK_IMAGE} bs=8k seek=1
+
 
 sudo umount -R $TMPMOUNT
 sudo cryptsetup close $ENCRYNAME

--- a/installer.sh
+++ b/installer.sh
@@ -105,7 +105,7 @@ SQFSROOT="archlinux-$DEVICE-$USR_ENV-$SQFSDATE.sqfs"
 echo -e "\e[1mWhich filesystem would you like to use?\e[0m"
 select OPTION in "ext4" "f2fs"; do
     case $OPTION in
-        "ext4" ) FILESYSTEM="ext4"; gbreak;;
+        "ext4" ) FILESYSTEM="ext4"; break;;
         "f2fs" ) FILESYSTEM="f2fs"; break;;
     esac
 done


### PR DESCRIPTION
These changes allow this script to successfully install to PinePhone Pro. However, this script does not seem to work with the pinephone-pro sqfs from 24 January 2022 located on the `DOWNLOAD_SERVER`. It only started working when I built the sqfs with the most up-to-date version of [arch-pine64-build](https://github.com/dreemurrs-embedded/arch-pine64-build). So the script won't work until the server has updated versions of the sqfs.  

I'm open to any suggestions for improving these changes.

Closes #12.