### PR TITLE
Abort if mount fails

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -175,7 +175,10 @@ sudo cryptsetup open $ROOTPART $ENCRYNAME
 sudo mkfs.vfat $BOOTPART
 sudo $MKFS $ENCRYPART
 
-sudo mount $ENCRYPART $TMPMOUNT
+sudo mount $ENCRYPART $TMPMOUNT || {
+    error "Failed to mount encrypted partition. Aborting."
+    exit 2
+}
 sudo mkdir $TMPMOUNT/boot
 sudo mount $BOOTPART $TMPMOUNT/boot
 


### PR DESCRIPTION
See #17 where `mount` has failed. In that case the script should exit.